### PR TITLE
fix missing ledgerIndex header for offers_exercised csv/array format

### DIFF
--- a/api/routes/offersExercised.js
+++ b/api/routes/offersExercised.js
@@ -149,7 +149,7 @@ function offersExercised (params, callback, unlimit) {
     
     // prepare results to send back
     if (options.view.reduce === false) {
-      rows.push(['time','price','baseAmount','counterAmount','account','counterparty','tx_hash']);
+      rows.push(['time','price','baseAmount','counterAmount','account','counterparty','tx_hash','ledgerIndex']);
       resRows.forEach(function(row){
         var time = row.key ? row.key.slice(1) : row.value[5];
         rows.push([


### PR DESCRIPTION
While documenting the API, I found a bug and fixed it:
the offers_exercised method, when executed in "csv" format or with no format string (so, array format) returns 7 columns of data, but the header row only contains 6 columns -- the final column, ledgerIndex, is omitted.

This one-line fix solves the problem in both formats and has been tested on my local machine.
(Incidentally, I have also confirmed that the installation instructions work -- after I resolved some npm warnings.)